### PR TITLE
Fix crash with zope.interface 4.0.1

### DIFF
--- a/pyramid_beaker/__init__.py
+++ b/pyramid_beaker/__init__.py
@@ -15,6 +15,7 @@ def BeakerSessionFactoryConfig(**options):
     """ Return a Pyramid session factory using Beaker session settings
     supplied directly as ``**options``"""
 
+    @implementer(ISession)
     class PyramidBeakerSessionObject(SessionObject):
         _options = options
         _cookie_on_exception = _options.pop('cookie_on_exception', True)
@@ -90,7 +91,7 @@ def BeakerSessionFactoryConfig(**options):
                 token = self.new_csrf_token()
             return token
 
-    return implementer(ISession)(PyramidBeakerSessionObject)
+    return PyramidBeakerSessionObject
 
 
 def call_save(wrapped):


### PR DESCRIPTION
This fixes the same bug as in https://github.com/Pylons/pyramid/issues/604 with Pyramid. Basically zope.interface 4.0.0 now yields with the implements function that just was failing silently before.

This change make it work with zope.interface 4.0.0
