### PR TITLE
Update session callback

### DIFF
--- a/pyramid_beaker/__init__.py
+++ b/pyramid_beaker/__init__.py
@@ -25,8 +25,8 @@ def BeakerSessionFactoryConfig(**options):
             SessionObject.__init__(self, request.environ, **self._options)
             def session_callback(request, response):
                 exception = getattr(request, 'exception', None)
-                if (exception is None or self._cookie_on_exception
-                    and self.accessed()):
+                if (exception is None or self._cookie_on_exception) \
+                    and self.accessed():
                     self.persist()
                     headers = self.__dict__['_headers']
                     if headers['set_cookie'] and headers['cookie_out']:


### PR DESCRIPTION
Cookies are being set on requests regardless of the fact that the session was never accessed. This was causing me problems because I have a cookie path set to something other than what my static resources live under. So all calls to all static resources were generating a new cookie which was being sent back to my client, clobbering the real cookie.
