### PR TITLE
Fix operator precedence

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+unreleased
+----------
+
+ - Fixed a bug causing session saving even when it is not needed. See
+   https://github.com/Pylons/pyramid_beaker/pull/28
+
 0.8 (2013-06-28)
 ----------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -123,3 +123,5 @@ Contributors
 - Michael Merickel, 2011/11/13
 
 - Patricio Paez, 2012/03/24
+
+- Aleksandr Dezhin, 2015/06/24

--- a/pyramid_beaker/__init__.py
+++ b/pyramid_beaker/__init__.py
@@ -25,8 +25,10 @@ def BeakerSessionFactoryConfig(**options):
             SessionObject.__init__(self, request.environ, **self._options)
             def session_callback(request, response):
                 exception = getattr(request, 'exception', None)
-                if (exception is None or self._cookie_on_exception
-                    and self.accessed()):
+                if (
+                    (exception is None or self._cookie_on_exception)
+                    and self.accessed()
+                ):
                     self.persist()
                     headers = self.__dict__['_headers']
                     if headers['set_cookie'] and headers['cookie_out']:


### PR DESCRIPTION
Because `true or foo and bar` is always `true`.
