### PR TITLE
prep for 0.9

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
-unreleased
-----------
+0.9 (2024-03-29)
+----------------
 
  - Fixed a bug causing session saving even when it is not needed. See
    https://github.com/Pylons/pyramid_beaker/pull/28

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ copyright = '2012-%s, Agendaless Consulting <chrism@plope.com>' % thisyear
 # other places throughout the built documents.
 #
 # The short X.Y version.
-version = '0.8'
+version = '0.9'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ testing_extras = [
     ]
 
 setup(name='pyramid_beaker',
-      version='0.8',
+      version='0.9',
       description='Beaker session factory backend for Pyramid',
       long_description=README + '\n\n' +  CHANGES,
       classifiers=[


### PR DESCRIPTION
I have uploaded releases based on this PR to https://m.devpi.net/fschulze/dev/pyramid-beaker/0.9.